### PR TITLE
Now skips year if there are already more than 300 records in db and i…

### DIFF
--- a/DataCollectionTrigger/DataCollection.cs
+++ b/DataCollectionTrigger/DataCollection.cs
@@ -10,7 +10,7 @@ namespace DataCollectionTrigger
     public class DataCollection
     {
         [FunctionName("DataCollectionTrigger")]
-        public async Task Run([TimerTrigger("0 3 20 * * *")]TimerInfo myTimer, ILogger log)
+        public async Task Run([TimerTrigger("40 38 14 * * *")]TimerInfo myTimer, ILogger log)
         {
             string connectionString = System.Environment.GetEnvironmentVariable("GamesDatabase", EnvironmentVariableTarget.Process);
 

--- a/NhlDataCollection/DataAccess/GamesDA.cs
+++ b/NhlDataCollection/DataAccess/GamesDA.cs
@@ -66,6 +66,19 @@ namespace NhlDataCollection.DataAccess
             return MapDataRowToGame(gameTable.Rows[0]);
         }
 
+        public int GetGameCountBySeason(int year)
+        {
+            int count;
+            string sql = $"SELECT COUNT(id) FROM Game WHERE seasonStartYear = {year};";
+            using (SqlConnection conn = new SqlConnection(_connectionString))
+            {
+                SqlCommand cmd = new SqlCommand(sql, conn);
+                conn.Open();
+                count = (int)cmd.ExecuteScalar();
+            }
+            return count;
+        }
+
         public List<Game> GetGames()
         {
             var games = new List<Game>();
@@ -79,20 +92,6 @@ namespace NhlDataCollection.DataAccess
                 games.Add(MapDataRowToGame(row));
             }
             return games;
-        }
-
-        public int GetMostRecentIdBySeasonStartYear(int year)
-        {
-            int id;
-            string sql = $"SELECT max(SUBQUERY.id) FROM (SELECT * FROM Game WHERE seasonStartYear = {year}) AS SUBQUERY";
-            using (SqlConnection conn = new SqlConnection(_connectionString))
-            {
-                SqlCommand cmd = new SqlCommand(sql, conn);
-                conn.Open();
-                id = (int)cmd.ExecuteScalar();
-            }
-
-            return id;
         }
 
         public Game MapDataRowToGame(DataRow row)

--- a/NhlDataCollection/DataAccess/IGamesDA.cs
+++ b/NhlDataCollection/DataAccess/IGamesDA.cs
@@ -9,6 +9,6 @@ namespace NhlDataCollection.DataAccess
         Game GetGameById(int id);
         List<Game> GetGames();
         Game MapDataRowToGame(DataRow row);
-        int GetMostRecentIdBySeasonStartYear(int year);
+        int GetGameCountBySeason(int year);
     }
 }


### PR DESCRIPTION
…ts not the current year (doesn't save to database until all records are collected so it shouldn't save less than all games for a season). Removed old method of checking latest game id as scheduling reworks makes going down the list not viable. Goes through every game of the last year to make sure they do not exist