### PR TITLE
Fix Successive Runs

### DIFF
--- a/DataAccess/CleanedGamesRepository/CleanedGamesDA.cs
+++ b/DataAccess/CleanedGamesRepository/CleanedGamesDA.cs
@@ -7,10 +7,12 @@ namespace DataAccess.CleanedGamesRepository
     public class CleanedGamesDA : ICleanedGamesDA
     {
         private string _connectionString;
+        private List<int> _cachedGameIds;
 
         public CleanedGamesDA(string connectionString)
         {
             _connectionString = connectionString;
+            _cachedGameIds = new List<int>();
         }
 
         public void AddGames(List<CleanedGame> games)
@@ -71,6 +73,27 @@ namespace DataAccess.CleanedGamesRepository
                 da.Update(gameTable);
             }
 
+        }
+
+        public void CacheGameIds()
+        {
+            var dataTable = new DataTable();
+            using (var da = new SqlDataAdapter($"SELECT id FROM CleanedGame", _connectionString))
+            {
+                da.Fill(dataTable);
+            }
+            foreach (DataRow row in dataTable.Rows)
+            {
+                _cachedGameIds.Add(Convert.ToInt32(row["id"]));
+            }
+        }
+
+        public bool GetIfGameExistsByIdFromCache(int id)
+        {
+            int gameExists = _cachedGameIds.FirstOrDefault(i => i == id);
+            if(gameExists == 0)
+                return false;
+            return true;
         }
     }
 }

--- a/DataAccess/CleanedGamesRepository/ICleanedGamesDA.cs
+++ b/DataAccess/CleanedGamesRepository/ICleanedGamesDA.cs
@@ -4,5 +4,7 @@ namespace DataAccess.CleanedGamesRepository
     public interface ICleanedGamesDA
     {
         void AddGames(List<CleanedGame> games);
+        void CacheGameIds();
+        bool GetIfGameExistsByIdFromCache(int id);
     }
 }

--- a/NhlDataCleaning/DataCleaner.cs
+++ b/NhlDataCleaning/DataCleaner.cs
@@ -36,10 +36,13 @@ namespace NhlDataCleaning
         }
         private List<CleanedGame> CleanGames(List<Game> seasonsGames)
         {
+            _cleanedGamesDA.CacheGameIds();
             var cleanedGames = new List<CleanedGame>();
             seasonsGames = seasonsGames.OrderBy(i => i.id).Reverse().ToList();
             foreach(var game in seasonsGames)
             {
+                if (GameExists(game))
+                    continue;
                 var homeGames = GetTeamGames(seasonsGames, game.homeTeamName, game.id);
                 var awayGames = GetTeamGames(seasonsGames, game.awayTeamName, game.id);
                 var cleanedGame = new CleanedGame()
@@ -93,6 +96,12 @@ namespace NhlDataCleaning
 
             return cleanedGames;
         }
+
+        private bool GameExists(Game game)
+        {
+            return _cleanedGamesDA.GetIfGameExistsByIdFromCache(game.id);
+        }
+
         private List<Game> GetTeamGames(List<Game> seasonsGames, string teamName, int id)
         {
             // Get games that happened before current game and include the team


### PR DESCRIPTION
fixes #25 
Can now run multiple times and dataCleaner does not error about duplicates. Cache games and make sure that if the game already exists, skip the computation.